### PR TITLE
rtc: sophgo: synchronize time with analog seconds clock

### DIFF
--- a/drivers/rtc/rtc-cv1800.c
+++ b/drivers/rtc/rtc-cv1800.c
@@ -28,9 +28,20 @@
  */
 #define MACRO_RO_T             0x14A8
 #define MACRO_RG_SET_T         0x1498
+#define MACRO_DA_CLEAR_ALL     0x1480
+#define MACRO_DA_SOC_READY     0x148C
+#define MACRO_RG_DEFD          0x1494
+#define MACRO_DA_LATCH_PASS    0x1488
 
 #define ALARM_ENABLE_MASK      BIT(0)
 #define SEL_SEC_PULSE          BIT(31)
+
+/*
+ * An uninitialized analog seconds counter starts from the Unix
+ * epoch and continues counting. Ignore timestamps before this
+ * threshold when restoring the retained RTC value.
+ */
+#define CV1800_RTC_MIN_VALID_TIMESTAMP 0x30000000
 
 struct cv1800_rtc_priv {
 	struct rtc_device *rtc_dev;
@@ -64,6 +75,24 @@ static int cv1800_rtc_alarm_irq_enable(struct device *dev, unsigned int enabled)
 	regmap_write(info->rtc_map, ALARM_ENABLE, enabled);
 
 	return 0;
+}
+
+static void cv1800_rtc_sync_from_analog(struct device *dev)
+{
+	struct cv1800_rtc_priv *info = dev_get_drvdata(dev);
+	u32 sec_ro_t;
+
+	regmap_read(info->rtc_map, MACRO_RO_T, &sec_ro_t);
+
+	if (sec_ro_t > CV1800_RTC_MIN_VALID_TIMESTAMP) {
+		/* Synchronize digital RTC counter */
+		regmap_write(info->rtc_map, SET_SEC_CNTR_VAL, sec_ro_t);
+		regmap_write(info->rtc_map, SET_SEC_CNTR_TRIG, 1);
+
+		cv1800_rtc_enable(dev);
+	} else {
+		dev_dbg(dev, "Analog seconds clock not initialized\n");
+	}
 }
 
 static int cv1800_rtc_set_alarm(struct device *dev, struct rtc_wkalrm *alrm)
@@ -113,7 +142,6 @@ static int cv1800_rtc_read_time(struct device *dev, struct rtc_time *tm)
 		return -EINVAL;
 
 	regmap_read(info->rtc_map, SEC_CNTR_VAL, &sec);
-
 	rtc_time64_to_tm(sec, tm);
 
 	return 0;
@@ -129,7 +157,17 @@ static int cv1800_rtc_set_time(struct device *dev, struct rtc_time *tm)
 	regmap_write(info->rtc_map, SET_SEC_CNTR_VAL, sec);
 	regmap_write(info->rtc_map, SET_SEC_CNTR_TRIG, 1);
 
+	/* Analog seconds clock initialization follow TRM */
+	regmap_write(info->rtc_map, MACRO_DA_SOC_READY, 1);
+	regmap_write(info->rtc_map, MACRO_DA_CLEAR_ALL, 1);
+	regmap_write(info->rtc_map, MACRO_DA_CLEAR_ALL, 0);
+
 	regmap_write(info->rtc_map, MACRO_RG_SET_T, sec);
+
+	regmap_write(info->rtc_map, MACRO_DA_LATCH_PASS, 1);
+	regmap_write(info->rtc_map, MACRO_DA_LATCH_PASS, 0);
+	regmap_write(info->rtc_map, MACRO_RG_SET_T, 0);
+	regmap_write(info->rtc_map, MACRO_DA_SOC_READY, 0);
 
 	cv1800_rtc_enable(dev);
 
@@ -194,6 +232,8 @@ static int cv1800_rtc_probe(struct platform_device *pdev)
 	if (ret)
 		return dev_err_probe(&pdev->dev, ret,
 				     "cannot register interrupt handler\n");
+
+	cv1800_rtc_sync_from_analog(&pdev->dev);
 
 	return devm_rtc_register_device(rtc->rtc_dev);
 }


### PR DESCRIPTION
Implement support for the analog seconds counter by restoring the digital RTC counter from the analog counter during probe and updating the analog counter when setting the RTC time.